### PR TITLE
Add Arch test container

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         variant:
+          - fakemachine-arch
           - fakemachine-bullseye
           - fakemachine-bookworm
     steps:

--- a/Dockerfile.fakemachine-arch
+++ b/Dockerfile.fakemachine-arch
@@ -1,0 +1,11 @@
+FROM archlinux:base-devel
+
+# Bits needed to run fakemachine
+RUN pacman -Syu --noconfirm qemu-headless \
+                            busybox \
+                            linux \
+                            --assume-installed initramfs
+
+# Bits needed to build fakemachine
+RUN pacman -Syu --noconfirm go \
+                            git


### PR DESCRIPTION
Instead of pulling GCC and friends manually, we opt for the "-devel"
container, which is a requirement when building anything on Arch.

On the runtime dependencies side - we pull the headless qemu and
omit/ignore the initramfs.

We don't need the fancy graphics and nor the /boot/vmlinuz* files,
pulled by each respective package.

Note:
User mode linux is not a thing in the official repositories. There are
some user build recipes in AUR, which we can look as follow-up.
