### PR TITLE
Allow workflow to be manually triggered

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,5 +1,6 @@
 name: Create and publish a Docker image
 on:
+ workflow_dispatch:
  push:
  pull_request:
  schedule:


### PR DESCRIPTION
Currently the workflow cannot be manually started; we
have to wait for the timer to expire or a manual push
to main. Let's allow the workflow to be manually ran.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>