### PR TITLE
Setup bors-ng

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -2,6 +2,8 @@ name: Build and publish Docker images
 on:
  workflow_dispatch:
  push:
+  branches-ignore:
+   - '*.tmp'
  pull_request:
  schedule:
   # New image every monday morning
@@ -97,3 +99,14 @@ jobs:
             BASE_REGISTRY=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
             BASE_IMAGE=fakemachine-${{ matrix.variant }}
             BASE_TAG=${{ steps.meta-fakemachine.outputs.version }}
+
+  # Job to key the bors success status against
+  bors:
+    name: bors
+    if: success()
+    needs:
+      - build-containers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark the job as a success
+        run: exit 0

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,1 @@
+status = [ "bors" ]


### PR DESCRIPTION
Add support for using bors to do pre-merge testing. In particular avoid running CI on branches ending in .tmp as bors uses those for preperation and add a new dummy job to key the bors status against to avoid having to call out all test jobs specifically which would be hard to maintain.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>