### PR TITLE
Add support for user-mode-linux fakemachine backend to Debian containers

### DIFF
--- a/Dockerfile.fakemachine-debian
+++ b/Dockerfile.fakemachine-debian
@@ -13,7 +13,9 @@ RUN apt-get update  && \
                                                busybox \
                                                linux-image-amd64 \
                                                systemd \
-                                               dbus
+                                               dbus \
+                                               libslirp-helper \
+                                               user-mode-linux
 
 # Bits needed to build fakemachine
 RUN apt-get update  && \


### PR DESCRIPTION
Currently the debian test containers only support the kvm/qemu fakemachine backends; add support for the user-mode-linux backend.