### PR TITLE
arch: Install qemu-base rather than qemu-headless

### DIFF
--- a/Dockerfile.fakemachine-arch
+++ b/Dockerfile.fakemachine-arch
@@ -1,7 +1,7 @@
 FROM archlinux:base-devel
 
 # Bits needed to run fakemachine
-RUN pacman -Syu --noconfirm qemu-headless \
+RUN pacman -Syu --noconfirm qemu-base \
                             busybox \
                             linux \
                             --assume-installed initramfs


### PR DESCRIPTION
According to the Arch linux packaging news, qemu-base now replaces qemu-headless. Seems like the qemu-base has now gone away from the repos; let's install qemu-base instead.

Link: https://archlinux.org/news/qemu-700-changes-split-package-setup/

cc @evelikov-work 