### PR TITLE
arch: Drop caches after package installs

### DIFF
--- a/Dockerfile.debos-arch
+++ b/Dockerfile.debos-arch
@@ -5,7 +5,9 @@ FROM $BASE_REGISTRY/$BASE_IMAGE:$BASE_TAG
 
 # Bits needed to run debos test suite
 RUN pacman -Syu --noconfirm dpkg \
-                            unzip
+                            unzip \
+    && find /var/cache/pacman/pkg -mindepth 1 -delete
 
 # Bits needed to build debos
-RUN pacman -Syu --noconfirm ostree
+RUN pacman -Syu --noconfirm ostree \
+    && find /var/cache/pacman/pkg -mindepth 1 -delete

--- a/Dockerfile.fakemachine-arch
+++ b/Dockerfile.fakemachine-arch
@@ -4,8 +4,11 @@ FROM archlinux:base-devel
 RUN pacman -Syu --noconfirm qemu-base \
                             busybox \
                             linux \
-                            --assume-installed initramfs
+                            --assume-installed initramfs \
+    && find /var/cache/pacman/pkg -mindepth 1 -delete
+
 
 # Bits needed to build fakemachine
 RUN pacman -Syu --noconfirm go \
-                            git
+                            git \
+    && find /var/cache/pacman/pkg -mindepth 1 -delete


### PR DESCRIPTION
pacman likes to keep the installed package cached locally increasing the size of the final docker images; Drop the packages by hand after each pacman run