### PR TITLE
arch: Pin to older snapshot

### DIFF
--- a/Dockerfile.fakemachine-arch
+++ b/Dockerfile.fakemachine-arch
@@ -1,4 +1,7 @@
-FROM archlinux:base-devel
+#FROM archlinux:base-devel
+FROM archlinux/archlinux:base-devel-20230724.0.167197
+
+RUN echo 'Server=https://archive.archlinux.org/repos/2023/08/23/$repo/os/$arch' > /etc/pacman.d/mirrorlist
 
 # Bits needed to run fakemachine
 RUN pacman -Syu --noconfirm qemu-base \


### PR DESCRIPTION
qemu 8.1 has a bug which causes it to break with the fakemachine qemu backend. Upstream this is likely fixed by
https://gitlab.com/qemu-project/qemu/-/commit/0d58c660.

Debian's 8.1 has this patch included, Arch does not. To allow CI runs with arch pin it to an older version temporarily until a fixed qemu is available in arch as well.