### PR TITLE
Revert "arch: Pin to older snapshot"

### DIFF
--- a/Dockerfile.fakemachine-arch
+++ b/Dockerfile.fakemachine-arch
@@ -1,7 +1,4 @@
-#FROM archlinux:base-devel
-FROM archlinux/archlinux:base-devel-20230724.0.167197
-
-RUN echo 'Server=https://archive.archlinux.org/repos/2023/08/23/$repo/os/$arch' > /etc/pacman.d/mirrorlist
+FROM archlinux:base-devel
 
 # Bits needed to run fakemachine
 RUN pacman -Syu --noconfirm qemu-base \


### PR DESCRIPTION
qemu in latest arch now has a fix for the bug which causes fakemachine to break with the qemu backend. Revert the commit to build with latest arch.

This reverts commit becf4bcdd8783bab80e4c26287da46ccca593e81.