### PR TITLE
Keep GitHub workflow alive

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -74,6 +74,16 @@ jobs:
           build-args: |
             VARIANT=${{ matrix.variant }}
 
+  # Keep workflow alive
+  # See https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1.2.1
+
   # Job to key success status against
   allgreen:
     name: allgreen


### PR DESCRIPTION
GitHub disables workflows if there is no activity in the repository after 60 days. Run a separate standalone job to re-enable the workflow on a regular scheduled job.

Fixes: #34