### PR TITLE
Build forky test containers

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -35,6 +35,8 @@ jobs:
             dockerfile: debian
           - variant: trixie
             dockerfile: debian
+          - variant: forky
+            dockerfile: debian
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Since forky is now the new Debian testing release, build the test containers for the new release.