### PR TITLE
Install e2fsprogs

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -16,7 +16,8 @@ RUN apt-get update  && \
                                                systemd \
                                                dbus \
                                                libslirp-helper \
-                                               user-mode-linux
+                                               user-mode-linux \
+                                               e2fsprogs
 
 # Debian bookworm split systemd-resolved from systemd into separate package
 RUN if [ "$VARIANT" != "bullseye" ] ; then \


### PR DESCRIPTION
In https://github.com/go-debos/fakemachine/issues/237 it was discovered that the issue with the CI is the lack of mkfs.ext4 in the Trixie test-container. Somewhere along the line that package is no longer installed (due to some package dependency chain changing) in trixie anymore.

Install e2fsprogs manually for all of the Debian-based containers.