### PR TITLE
Remove Debian bullseye & bookworm container images

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -22,17 +22,9 @@ jobs:
       packages: write
     strategy:
       matrix:
-        variant:
-          - arch
-          - bullseye
-          - bookworm
         include:
           - variant: arch
             dockerfile: arch
-          - variant: bullseye
-            dockerfile: debian
-          - variant: bookworm
-            dockerfile: debian
           - variant: trixie
             dockerfile: debian
           - variant: forky

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,4 +1,4 @@
-ARG VARIANT=bullseye
+ARG VARIANT=trixie
 FROM debian:${VARIANT}-slim
 
 ARG VARIANT
@@ -18,11 +18,6 @@ RUN apt-get update  && \
                                                libslirp-helper \
                                                user-mode-linux \
                                                e2fsprogs
-
-# Debian bookworm split systemd-resolved from systemd into separate package
-RUN if [ "$VARIANT" != "bullseye" ] ; then \
-      apt-get install --no-install-recommends -y systemd-resolved; \
-    fi
 
 # Bits needed to run debos
 RUN apt-get update  && \


### PR DESCRIPTION
Since we no longer test debos/fakemachine in bullsye & bookworm in the related projects, remove the container image build jobs to avoid wasting CI time and bitrotting.