### PR TITLE
debian: Install systemd-resolved again

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -14,6 +14,7 @@ RUN apt-get update  && \
                                                busybox \
                                                linux-image-amd64 \
                                                systemd \
+                                               systemd-resolved \
                                                dbus \
                                                libslirp-helper \
                                                user-mode-linux \


### PR DESCRIPTION
In eb1f4a18d2f0 ("Remove Debian bullseye & bookworm container images") the installation of systemd-resolved was accidently removed. Install it.