### PR TITLE
Create/update issue when scheduled CI job fails

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -90,3 +90,50 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+
+  # Notify on job failure
+  notify-on-failure:
+    runs-on: ubuntu-latest
+    needs:
+      - allgreen
+    if: >-
+     ${{
+         always() &&
+         needs.allgreen.result == 'failure' &&
+         github.event_name == 'schedule' &&
+         github.repository == 'go-debos/test-containers'
+      }}
+    steps:
+      - name: Create or update failure issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            /* Reuse a single issue to avoid spam */
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue is:open "Scheduled CI job failed"`
+            });
+            const body = [
+              `### Scheduled CI job failed`,
+              `- Workflow: ${process.env.GITHUB_WORKFLOW}`,
+              `- Run: ${context.runId}`,
+              `- Commit: ${process.env.GITHUB_SHA}`,
+              `- Branch/Ref: ${process.env.GITHUB_REF}`,
+              `- URL: https://github.com/${owner}/${repo}/actions/runs/${context.runId}`,
+              ``,
+              `Please investigate and close this issue once fixed.`
+            ].join("\n");
+
+            if (search.data.items.length > 0) {
+              const issue = search.data.items[0];
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issue.number, body
+              });
+            } else {
+              await github.rest.issues.create({
+                owner, repo,
+                title: "Scheduled CI job failed",
+                body,
+              });
+            }


### PR DESCRIPTION
It currently is quite difficult to see when a scheduled CI job (e.g. a weekly build/test run) fails; which can cause bugs to go unnoticed for a while. Add in a job to create an issue when the job fails, to alert any users who watch the project's issues.

Link: https://github.com/go-debos/fakemachine/pull/243