### PR TITLE
Remove user-mode-linux support

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -16,8 +16,6 @@ RUN apt-get update  && \
                                                systemd \
                                                systemd-resolved \
                                                dbus \
-                                               libslirp-helper \
-                                               user-mode-linux \
                                                e2fsprogs
 
 # Bits needed to run debos


### PR DESCRIPTION
debos no longer supports user-mode-linux, remove the package from the test containers.