### PR TITLE
Add Ubuntu container variant

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -29,9 +29,9 @@ jobs:
 
   build-containers:
     runs-on: ubuntu-latest
-    name: Build ${{ matrix.variant }} container
+    name: Build ${{ matrix.distro }}/${{ matrix.variant }} container
     env:
-      IMAGE_TAG: ${{ github.repository }}-${{ matrix.variant }}-testbuild
+      IMAGE_TAG: ${{ github.repository }}-${{ matrix.distro }}-${{ matrix.variant }}-testbuild
     permissions:
       contents: read
       packages: write
@@ -40,11 +40,22 @@ jobs:
         include:
           - variant: arch
             dockerfile: arch
+            distro: arch
+            image: base-devel
           - variant: trixie
             dockerfile: debian
+            distro: debian
+            image: trixie-slim
           - variant: forky
             dockerfile: debian
+            distro: debian
+            image: forky-slim
+          - variant: plucky
+            dockerfile: debian
+            distro: ubuntu
+            image: plucky
           - variant: fedora
+            distro: fedora
             dockerfile: fedora
     steps:
       - name: Checkout repository
@@ -84,7 +95,8 @@ jobs:
           tags: ${{ env.IMAGE_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VARIANT=${{ matrix.variant }}
+            DISTRO=${{ matrix.distro }}
+            IMAGE=${{ matrix.image }}
 
       - name: Checkout fakemachine (for unit tests)
         uses: actions/checkout@v6
@@ -142,7 +154,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VARIANT=${{ matrix.variant }}
+            DISTRO=${{ matrix.distro }}
+            IMAGE=${{ matrix.image }}
 
   # Cleanup GitHub container registry
   cleanup-containers:
@@ -157,13 +170,13 @@ jobs:
           account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: >-
-            test-containers/arch
-            test-containers/bookworm
-            test-containers/bullseye
-            test-containers/fedora
-            test-containers/forky
-            test-containers/plucky
-            test-containers/trixie
+            test-containers/arch/arch
+            test-containers/debian/bookworm
+            test-containers/debian/bullseye
+            test-containers/debian/trixie
+            test-containers/debian/forky
+            test-containers/fedora/fedora
+            test-containers/ubuntu/plucky
           image-tags: "!latest"
           cut-off: 6m
           keep-n-most-recent: 10

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,21 +1,35 @@
 # SPDX-FileCopyrightText: 2017-2026 Collabora Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG VARIANT=trixie
-FROM debian:${VARIANT}-slim
+ARG DISTRO=debian
+ARG IMAGE=trixie-slim
+FROM ${DISTRO}:${IMAGE}
 
-ARG VARIANT
+ARG DISTRO
+ARG IMAGE
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Always install procps in case the docker file gets used in jenkins
 RUN apt update && apt-get install  --no-install-recommends -y procps
+
+# Install kernel
+# (Debian uses linux-image-amd64; ubuntu uses linux-image-generic)
+RUN if [ "${DISTRO}" = "debian" ]; then \
+      KERNEL_PACKAGE=linux-image-amd64; \
+    elif [ "${DISTRO}" = "ubuntu" ]; then \
+      KERNEL_PACKAGE=linux-image-generic; \
+    else \
+      echo "Unsupported DISTRO=${DISTRO}" >&2; \
+      exit 1; \
+    fi; \
+    apt-get update && \
+    apt-get install --no-install-recommends -y "$KERNEL_PACKAGE"
 
 # Bits needed to run fakemachine
 RUN apt-get update  && \
     apt-get install --no-install-recommends -y qemu-system-x86 \
                                                qemu-user-binfmt \
                                                busybox \
-                                               linux-image-amd64 \
                                                systemd \
                                                systemd-resolved \
                                                dbus \


### PR DESCRIPTION
Introduce an Ubuntu-based container variant for building/testing debos
and fakemachine. This reuses the existing Debian Dockerfile as the base
and selects the appropriate Ubuntu base image and kernel package via
build args while keeping the runtime and build dependencies aligned with
the Debian variant.

Closes: https://github.com/go-debos/test-containers/issues/10