### PR TITLE
debian: Install qemu-user-binfmt instead of qemu-user-static

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -10,7 +10,7 @@ RUN apt update && apt-get install  --no-install-recommends -y procps
 # Bits needed to run fakemachine
 RUN apt-get update  && \
     apt-get install --no-install-recommends -y qemu-system-x86 \
-                                               qemu-user-static \
+                                               qemu-user-binfmt \
                                                busybox \
                                                linux-image-amd64 \
                                                systemd \


### PR DESCRIPTION
qemu-user-binfmt is the replacement of qemu-user-static. Install qemu-user-binfmt instead of qemu-user-static.